### PR TITLE
README: Remove Travis CI badge & use logo from main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
   <a href="https://www.zenodo.org">
     <img src="https://github.com/lnielsen/zenodo-docs-user/raw/master/assets/static/img/logos/zenodo-black-200.png">
   </a>
-  <br>
-  <a href="https://travis-ci.org/zenodo/zenodo-docs-user">
-    <img src="https://travis-ci.org/zenodo/zenodo-docs-user.svg?branch=master" alt="Build Status">
-  </a>
 </p>
 
 # Getting Started

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.zenodo.org">
-    <img src="https://github.com/lnielsen/zenodo-docs-user/raw/master/assets/static/img/logos/zenodo-black-200.png">
+    <img src="https://github.com/zenodo/zenodo-docs-user/raw/master/assets/static/img/logos/zenodo-black-200.png">
   </a>
 </p>
 


### PR DESCRIPTION
1. Removing the Travis CI badge from the README since we migrated to GitHub actions.
We could use [GitHub Action workflow badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge), but it's probably redundant with the green checkmark next to the last commit in the GitHub UI.
2. Using the main repo instead of a fork for the Zenodo logo in the README