### PR TITLE
bug: fix link

### DIFF
--- a/content/help/docs/communities/review-submissions/contents.lr
+++ b/content/help/docs/communities/review-submissions/contents.lr
@@ -7,7 +7,7 @@ body:
 Any Zenodo user can submit records to your community via two different methods:
 
 - [Submit for review](../../share/submit-for-review/) for unpublished records.
-- [Submit to community](../../share/submit-for-review/) for published records.
+- [Submit to community](../../share/submit-to-community/) for published records.
 
 The following sections explain how you as a community curator review these submissions.
 


### PR DESCRIPTION
Target link should be https://help.zenodo.org/docs/share/submit-to-community/