### PR TITLE
docs: fix common error with extra dash

### DIFF
--- a/content/help/docs/about/whats-changed/contents.lr
+++ b/content/help/docs/about/whats-changed/contents.lr
@@ -134,7 +134,7 @@ ref: deposit-versioning
 #### docstext ####
 text:
 
-When you create a new version of a record we previously copied all files over from the old to the new version. We have modified this behavior so you now are required to explicitly import the files from the previous version via simply clicking on **Import files**-button.
+When you create a new version of a record we previously copied all files over from the old to the new version. We have modified this behavior so you now are required to explicitly import the files from the previous version via simply clicking on **Import files** button.
 
 <img src="import-files.png" width="100%">
 
@@ -327,7 +327,7 @@ image: shared-links-new.png
 #### docsstep ####
 step: 3
 ----
-text: **New**: You can enable users to request access from record landing page by click the blue **Share**-button. In the pop-up click the **Access request** tab, and check the boxes to enable users and/or guests to request access.
+text: **New**: You can enable users to request access from record landing page by click the blue **Share** button. In the pop-up click the **Access request** tab, and check the boxes to enable users and/or guests to request access.
 ----
 image: shared-links-new3.png
 #### docstext ####

--- a/content/help/docs/about/whats-new/contents.lr
+++ b/content/help/docs/about/whats-new/contents.lr
@@ -194,7 +194,7 @@ Our new community features support sharing of many records among members of a co
 - **Preview**:  Gives the link holder access to preview a draft of a record (useful if you e.g. need a colleague to check a draft).
 - **Edit**: Gives the link holder access to edit the record.
 
-You access the new feature via the **Share**-button on the record landing page:
+You access the new feature via the **Share** button on the record landing page:
 
 <img src="share.png" />
 

--- a/content/help/docs/communities/curate/contents.lr
+++ b/content/help/docs/communities/curate/contents.lr
@@ -35,7 +35,7 @@ image: record.png
 #### docsstep ####
 step: 2
 ----
-text: Click the orange **Edit**-button. See [deposit](../../deposit/) for further details on editing a record.
+text: Click the orange **Edit** button. See [deposit](../../deposit/) for further details on editing a record.
 #### docsheader ####
 text: Remove a record
 ----
@@ -59,7 +59,7 @@ image: menu.png
 #### docsstep ####
 step: 4
 ----
-text: Click the red **Remove**-button.
+text: Click the red **Remove** button.
 ----
 image: dialog.png
 #### docsstep ####

--- a/content/help/docs/communities/manage-community-settings/add-pages/contents.lr
+++ b/content/help/docs/communities/manage-community-settings/add-pages/contents.lr
@@ -45,7 +45,7 @@ image: pages.png
 #### docsstep ####
 step: 2
 ----
-text: Click **Save**-button to persist the changes.
+text: Click **Save** button to persist the changes.
 
 #### docsheader ####
 text: Add a curation policy page
@@ -66,7 +66,7 @@ image: pages.png
 #### docsstep ####
 step: 2
 ----
-text: Click **Save**-button to persist the changes.
+text: Click **Save** button to persist the changes.
 
 #### docsheader ####
 text: Remove a page
@@ -86,4 +86,4 @@ image: pages.png
 #### docsstep ####
 step: 2
 ----
-text: Click **Save**-button to persist the changes.
+text: Click **Save** button to persist the changes.

--- a/content/help/docs/communities/manage-community-settings/contents.lr
+++ b/content/help/docs/communities/manage-community-settings/contents.lr
@@ -8,7 +8,7 @@ menu: /help/docs/communities
 ---
 body:
 
-You manage community settings from the **Settings**-tab on the community (see [below](#manage)). The settings allow you to edit the profile, provide a logo, set the review policy, provide about/curation policy pages and delete the community.
+You manage community settings from the **Settings** tab on the community (see [below](#manage)). The settings allow you to edit the profile, provide a logo, set the review policy, provide about/curation policy pages and delete the community.
 
 ---
 docs:

--- a/content/help/docs/communities/manage-community-settings/edit-profile/contents.lr
+++ b/content/help/docs/communities/manage-community-settings/edit-profile/contents.lr
@@ -40,7 +40,7 @@ text: Edit the basic information and funding information according to the follow
 #### docsstep ####
 step: 3
 ----
-text: Click **Save**-button to persist the changes.
+text: Click **Save** button to persist the changes.
 
 #### docsheader ####
 text: Add a logo
@@ -71,7 +71,7 @@ text: Go to your [community settings](../#manage).
 #### docsstep ####
 step: 2
 ----
-text: Click the red **Delete picture**-button to remove a previously uploaded logo.
+text: Click the red **Delete picture** button to remove a previously uploaded logo.
 ----
 image: logo-delete.png
 #### docsstep ####

--- a/content/help/docs/communities/manage-community-settings/review-policy/contents.lr
+++ b/content/help/docs/communities/manage-community-settings/review-policy/contents.lr
@@ -37,4 +37,4 @@ image: review-policy.png
 #### docsstep ####
 step: 3
 ----
-text: Click **Save**-button to persist the changes.
+text: Click **Save** button to persist the changes.

--- a/content/help/docs/communities/manage-members/cancel-invite/contents.lr
+++ b/content/help/docs/communities/manage-members/cancel-invite/contents.lr
@@ -26,7 +26,7 @@ text: [View the invitation](../view-invitations/) you would like to cancel.
 #### docsstep ####
 step: 2
 ----
-text: Click the **Cancel**-button in the top right corner.
+text: Click the **Cancel** button in the top right corner.
 ----
 image: cancel-button.png
 #### docsheader ####

--- a/content/help/docs/communities/manage-members/cancel-invite/contents.lr
+++ b/content/help/docs/communities/manage-members/cancel-invite/contents.lr
@@ -42,7 +42,7 @@ image: list-view.png
 #### docsstep ####
 step: 3
 ----
-text: Click the dropdown menu in the **Role**-column on the invitation you would like to edit, and select a new role.
+text: Click the dropdown menu in the **Role** column on the invitation you would like to edit, and select a new role.
 ----
 image: role-menu.png
 

--- a/content/help/docs/communities/manage-members/change-role/contents.lr
+++ b/content/help/docs/communities/manage-members/change-role/contents.lr
@@ -36,6 +36,6 @@ image: members.png
 #### docsstep ####
 step: 3
 ----
-text: Change the role of the member using the drop-down menu in the **Role**-column. Note that only community owners/managers can change roles, and that you cannot change your own role, nor as a manager change a member's role to an owner.
+text: Change the role of the member using the drop-down menu in the **Role** column. Note that only community owners/managers can change roles, and that you cannot change your own role, nor as a manager change a member's role to an owner.
 ----
 image: menu.png

--- a/content/help/docs/communities/manage-members/change-visibility/contents.lr
+++ b/content/help/docs/communities/manage-members/change-visibility/contents.lr
@@ -42,6 +42,6 @@ text: Find the member (or your own membership) in the list of members.
 #### docsstep ####
 step: 3
 ----
-text: Change the visibility to either **hidden** or **public** using the drop-down menu in the **Visibility**-column. Note that, community owners/managers can only set the visibility to **hidden** for other members.
+text: Change the visibility to either **hidden** or **public** using the drop-down menu in the **Visibility** column. Note that, community owners/managers can only set the visibility to **hidden** for other members.
 ----
 image:menu.png

--- a/content/help/docs/communities/manage-members/invite-member/contents.lr
+++ b/content/help/docs/communities/manage-members/invite-member/contents.lr
@@ -24,7 +24,7 @@ ref: invite
 #### docsstep ####
 step: 1
 ----
-text: Go to [**Members**](../#manage)-tab in your community and, click on the green **Invite**-button.
+text: Go to [**Members**](../#manage)-tab in your community and, click on the green **Invite** button.
 ----
 image: button.png
 #### docsstep ####
@@ -50,6 +50,6 @@ image: role.png
 #### docsstep ####
 step: 5
 ----
-text: Click the blue **Invite**-button. Each invited user will receive an email notification, and be able to see the invitation under [My requests](../../../get-started/navigating-zenodo/#dashboard).
+text: Click the blue **Invite** button. Each invited user will receive an email notification, and be able to see the invitation under [My requests](../../../get-started/navigating-zenodo/#dashboard).
 ----
 image: invite.png

--- a/content/help/docs/communities/manage-members/leave-community/contents.lr
+++ b/content/help/docs/communities/manage-members/leave-community/contents.lr
@@ -34,10 +34,10 @@ image: members.png
 #### docsstep ####
 step: 2
 ----
-text: Find your own membership (marked with a **You**-tag) and click the red **Leave**-button.
+text: Find your own membership (marked with a **You**-tag) and click the red **Leave** button.
 #### docsstep ####
 step: 3
 ----
-text: Confirm you want to leave by clicking the **Leave**-button in the dialog. IMPORTANT: Rejoining the community requires that an owner/manager sent you an new invitation to join.
+text: Confirm you want to leave by clicking the **Leave** button in the dialog. IMPORTANT: Rejoining the community requires that an owner/manager sent you an new invitation to join.
 ----
 image: leave-confirm.png

--- a/content/help/docs/communities/manage-members/leave-community/contents.lr
+++ b/content/help/docs/communities/manage-members/leave-community/contents.lr
@@ -34,7 +34,7 @@ image: members.png
 #### docsstep ####
 step: 2
 ----
-text: Find your own membership (marked with a **You**-tag) and click the red **Leave** button.
+text: Find your own membership (marked with a **You** tag) and click the red **Leave** button.
 #### docsstep ####
 step: 3
 ----

--- a/content/help/docs/communities/manage-members/remove-member/contents.lr
+++ b/content/help/docs/communities/manage-members/remove-member/contents.lr
@@ -29,6 +29,6 @@ image: members.png
 #### docsstep ####
 step: 2
 ----
-text: Find the member you'd like to remove and click the **Remove**-button.
+text: Find the member you'd like to remove and click the **Remove** button.
 
 

--- a/content/help/docs/communities/review-submissions/contents.lr
+++ b/content/help/docs/communities/review-submissions/contents.lr
@@ -43,7 +43,7 @@ ref: view
 #### docsstep ####
 step: 1
 ----
-text: Go to your community and click the **Request**-tab. The interface allows you to filter and search for requests.
+text: Go to your community and click the **Request** tab. The interface allows you to filter and search for requests.
 ----
 image: requests.png
 #### docsstep ####
@@ -64,7 +64,7 @@ text: View your community requests (see above), and click on the request you wan
 #### docsstep ####
 step: 2
 ----
-text: From the request detail page, click the **Record**-tab to see a preview of the record.
+text: From the request detail page, click the **Record** tab to see a preview of the record.
 ----
 image: detail.png
 #### docsstep ####

--- a/content/help/docs/communities/review-submissions/contents.lr
+++ b/content/help/docs/communities/review-submissions/contents.lr
@@ -70,7 +70,7 @@ image: detail.png
 #### docsstep ####
 step: 3
 ----
-text: Click the orange **Edit**-button to make changes to the record. NOTE: The edit button is only show for **unpublished records**. To edit a **published record**, you first have to accept the record.
+text: Click the orange **Edit** button to make changes to the record. NOTE: The edit button is only show for **unpublished records**. To edit a **published record**, you first have to accept the record.
 
 #### docsheader ####
 text: Comment on a submission

--- a/content/help/docs/deposit/manage-files/contents.lr
+++ b/content/help/docs/deposit/manage-files/contents.lr
@@ -49,7 +49,7 @@ image: add.png
 #### docsstep ####
 step: 2
 ----
-text: You can cancel the upload of large files while the upload is in progress by pressing the **Cancel**-button.
+text: You can cancel the upload of large files while the upload is in progress by pressing the **Cancel** button.
 ----
 image: inprogress.png
 #### docsheader ####

--- a/content/help/docs/deposit/manage-files/contents.lr
+++ b/content/help/docs/deposit/manage-files/contents.lr
@@ -79,7 +79,7 @@ text: Pending state
 ----
 ref: pending
 #### docstext ####
-text: You may experience a file displaying the state **Pending** in the **Progress**-column. The pending state means that a file is in progress of being uploaded. It happens e.g.
+text: You may experience a file displaying the state **Pending** in the **Progress** column. The pending state means that a file is in progress of being uploaded. It happens e.g.
 
 - If a file is uploaded from a different browser window or by a different user (multiple people can edit a draft)
 - If a file upload is broken off and you reload the browser page.

--- a/content/help/docs/deposit/manage-records/contents.lr
+++ b/content/help/docs/deposit/manage-records/contents.lr
@@ -46,11 +46,11 @@ text: You can edit the metadata (title, creators, etc) of a published record at 
 #### docsstep ####
 step: 1
 ----
-text: You can edit a record either by clicking the **Edit**-button on the record under **My uploads** (see above.)
+text: You can edit a record either by clicking the **Edit** button on the record under **My uploads** (see above.)
 #### docsstep ####
 step: 2
 ----
-text: Alternatively, from the record landing page you can also click the **Edit**-button.
+text: Alternatively, from the record landing page you can also click the **Edit** button.
 ----
 image: edit.png
 #### docsheader ####

--- a/content/help/docs/deposit/manage-versions/contents.lr
+++ b/content/help/docs/deposit/manage-versions/contents.lr
@@ -35,7 +35,7 @@ text: Go to the record landing page of the record you want to create a new versi
 #### docsstep ####
 step: 2
 ----
-text: Click the green **New version**-button to create a new version draft. The button is only displayed if you have permissions to edit the record.
+text: Click the green **New version** button to create a new version draft. The button is only displayed if you have permissions to edit the record.
 ----
 image: new-version.png
 #### docsstep ####
@@ -51,7 +51,7 @@ ref: import-files
 #### docsstep ####
 step: 1
 ----
-text: In files section of the deposit form, click the **Import files**-button to import files from a previous. Using this feature saves storage space as we don't duplicate the previous files.
+text: In files section of the deposit form, click the **Import files** button to import files from a previous. Using this feature saves storage space as we don't duplicate the previous files.
 ----
 image: import-files.png
 #### docsstep ####
@@ -84,4 +84,4 @@ text: Find the previous version you want to edit using e.g. [browse versions](#b
 #### docsstep ####
 step: 2
 ----
-text: Click the **Edit**-button to edit the previous version (see [edit published records](../manage-records/#edit)).
+text: Click the **Edit** button to edit the previous version (see [edit published records](../manage-records/#edit)).

--- a/content/help/docs/profile/change-password/contents.lr
+++ b/content/help/docs/profile/change-password/contents.lr
@@ -34,4 +34,4 @@ image: change-password.png
 #### docsstep ####
 step: 3
 ----
-text: Click **Change password**-button.
+text: Click **Change password** button.

--- a/content/help/docs/profile/viewing-devices/contents.lr
+++ b/content/help/docs/profile/viewing-devices/contents.lr
@@ -54,4 +54,4 @@ text: Find the device from the list of devices (see [viewing logged in devices](
 #### docsstep ####
 step: 2
 ----
-text: Click **Revoke**-button to logout the device. If the button says **Logout** is means the it's the authenticated session for your current device.
+text: Click **Revoke** button to logout the device. If the button says **Logout** is means the it's the authenticated session for your current device.

--- a/content/help/docs/share/access-requests/allow-requests/contents.lr
+++ b/content/help/docs/share/access-requests/allow-requests/contents.lr
@@ -13,7 +13,7 @@ docs:
 #### docsstep ####
 step: 1
 ----
-text: Go to the record you would like to share, and click the blue **Share**-button.
+text: Go to the record you would like to share, and click the blue **Share** button.
 ----
 image: button.png
 #### docsstep ####

--- a/content/help/docs/share/access-requests/allow-requests/contents.lr
+++ b/content/help/docs/share/access-requests/allow-requests/contents.lr
@@ -19,7 +19,7 @@ image: button.png
 #### docsstep ####
 step: 2
 ----
-text: In the Share access dialog, click the **Access requests**-tab.
+text: In the Share access dialog, click the **Access requests** tab.
 ----
 image: access.png
 #### docsstep ####

--- a/content/help/docs/share/access-requests/request-access/contents.lr
+++ b/content/help/docs/share/access-requests/request-access/contents.lr
@@ -41,7 +41,7 @@ text: Fill in:
 - Optionally, write a **message** to the owner (in particular if the owner has specified conditions under which they give access)
 - Tick the checkbox that you agree to that your full name and email address is shared with the record owners
 
-Finally click **Request access**-button to submit your request.
+Finally click **Request access** button to submit your request.
 #### docsstep ####
 step: 3
 ----
@@ -68,7 +68,7 @@ text: Fill in:
 - Optionally, a **message** to the owner (in particular if the owner has specified conditions under which they give access)
 - Tick the checkbox that you agree to that your full name and email address is shared with the record owners
 
-Finally click **Request access**-button to submit your request.
+Finally click **Request access** button to submit your request.
 #### docsstep ####
 step: 3
 ----

--- a/content/help/docs/share/link-sharing/contents.lr
+++ b/content/help/docs/share/link-sharing/contents.lr
@@ -31,7 +31,7 @@ ref: get
 #### docsstep ####
 step: 1
 ----
-text: Go to the record you would like to share, and click the blue **Share**-button.
+text: Go to the record you would like to share, and click the blue **Share** button.
 ----
 image: button.png
 #### docsstep ####
@@ -47,11 +47,11 @@ text: Optionally provide a title, set an expiration date and choose a permission
 #### docsstep ####
 step: 4
 ----
-text: Click the green **Create a new link**-button.
+text: Click the green **Create a new link** button.
 #### docsstep ####
 step: 5
 ----
-text: Click the green **Copy link**-button to copy the generated link to your clipboard.
+text: Click the green **Copy link** button to copy the generated link to your clipboard.
 ----
 image: secret.png
 
@@ -68,4 +68,4 @@ image: secret.png
 #### docsstep ####
 step: 2
 ----
-text: Click the **Delete**-button next to the link.
+text: Click the **Delete** button next to the link.

--- a/content/help/docs/share/link-sharing/contents.lr
+++ b/content/help/docs/share/link-sharing/contents.lr
@@ -37,7 +37,7 @@ image: button.png
 #### docsstep ####
 step: 2
 ----
-text: In the Share access dialog, click the **Links**-tab.
+text: In the Share access dialog, click the **Links** tab.
 ----
 image: links.png
 #### docsstep ####
@@ -62,7 +62,7 @@ ref: delete
 #### docsstep ####
 step: 1
 ----
-text: Find the link you want to delete in the **Links**-tab in the **Share access**-dialog (see above).
+text: Find the link you want to delete in the **Links** tab in the **Share access** dialog (see above).
 ----
 image: secret.png
 #### docsstep ####

--- a/content/help/docs/share/manage-submissions/cancel-submissions/contents.lr
+++ b/content/help/docs/share/manage-submissions/cancel-submissions/contents.lr
@@ -26,13 +26,13 @@ text: Go to the review request (see [view submissions](../view-submissions/#requ
 #### docsstep ####
 step: 2
 ----
-text: Click the **Cancel**-button in the top right corner.
+text: Click the **Cancel** button in the top right corner.
 ----
 image: request.png
 #### docsstep ####
 step: 3
 ----
-text: Leave an optional message to the curators, and confirm you want to cancel the request by pressing the **Cancel request**-button.
+text: Leave an optional message to the curators, and confirm you want to cancel the request by pressing the **Cancel request** button.
 ----
 image: confirm.png
 #### docsstep ####

--- a/content/help/docs/share/manage-submissions/reply-comments/contents.lr
+++ b/content/help/docs/share/manage-submissions/reply-comments/contents.lr
@@ -30,7 +30,7 @@ text: Go to the review request (see [view submissions](../view-submissions/#requ
 #### docsstep ####
 step: 2
 ----
-text: Write a comment in the comment field. You may use basic formatting. Submit the comment by clicking the green **Comment**-button.
+text: Write a comment in the comment field. You may use basic formatting. Submit the comment by clicking the green **Comment** button.
 ----
 image: conversation.png
 
@@ -47,7 +47,7 @@ image: edit.png
 #### docsstep ####
 step: 2
 ----
-text: Edit your comment. Once ready, click the green **Save**-button.
+text: Edit your comment. Once ready, click the green **Save** button.
 ----
 image: edit-form.png
 #### docsstep ####
@@ -71,7 +71,7 @@ image: edit.png
 #### docsstep ####
 step: 2
 ----
-text: Confirm that you want to delete the comment by clicking the red **Delete**-button.
+text: Confirm that you want to delete the comment by clicking the red **Delete** button.
 ----
 image: delete-confirm.png
 #### docsstep ####

--- a/content/help/docs/share/manage-submissions/view-submissions/contents.lr
+++ b/content/help/docs/share/manage-submissions/view-submissions/contents.lr
@@ -56,6 +56,6 @@ image: request-detail.png
 #### docsstep ####
 step: 2
 ----
-text: Click the **Record**-tab to see a preview of the record.
+text: Click the **Record** tab to see a preview of the record.
 ----
 image: record-preview.png

--- a/content/help/docs/share/submit-for-review/contents.lr
+++ b/content/help/docs/share/submit-for-review/contents.lr
@@ -49,7 +49,7 @@ text: Search a community and go to the community front page.
 #### docsstep ####
 step: 3
 ----
-text: Click the **New upload**-button on the community page.
+text: Click the **New upload** button on the community page.
 ----
 image: new-upload.png
 #### docsstep ####
@@ -61,7 +61,7 @@ image: deposit-form.png
 #### docsstep ####
 step: 4
 ----
-text: You can at any point change the community by pressing the **Change** or **Remove**-button.
+text: You can at any point change the community by pressing the **Change** or **Remove** button.
 ----
 image: change-remove.png
 
@@ -76,7 +76,7 @@ text: Upload files and describe the record as explained in the [deposit](../../d
 #### docsstep ####
 step: 2
 ----
-text: When ready, click the blue **Submit for review**-button.
+text: When ready, click the blue **Submit for review** button.
 ----
 image: submit.png
 #### docsstep ####
@@ -88,7 +88,7 @@ text: Confirm that you want to submit for review by:
 - Tick the checkbox that the record is published immediately when the curator accepts the record.
 - Optionally provide a message to the curator.
 
-Finally, click the **Submit record for review**-button.
+Finally, click the **Submit record for review** button.
 ----
 image: confirm.png
 #### docsstep ####

--- a/content/help/docs/share/submit-to-community/contents.lr
+++ b/content/help/docs/share/submit-to-community/contents.lr
@@ -49,7 +49,7 @@ image: menu.png
 #### docsstep ####
 step: 3
 ----
-text: Find the community you want to submit to and click the **Select**-button.
+text: Find the community you want to submit to and click the **Select** button.
 ----
 image: dialog.png
 #### docsstep ####
@@ -60,7 +60,7 @@ text: Confirm you want to submit the record to the community by:
 - Ticking the checkbox that curators gain view and edit access to your record.
 - Optionally, write a message to the curators.
 
-Finally, click the blue **Submit to community**-button.
+Finally, click the blue **Submit to community** button.
 ----
 image: confirm.png
 


### PR DESCRIPTION
> In English you "click the Submit button" not "click the Submit-button". 

This PR is a find and replace for all instances of '*-button' in *.lr files with "* button". The * prevents this from affecting filenames.

Examples (ctrl+F for button):
- https://help.osf.io/article/201-create-a-view-only-link-for-a-project
- https://help.figma.com/hc/en-us/articles/360038663154-Create-components-to-reuse-in-designs#01H8CYSGQ09HD5K7QNJYFZE78Q
- https://www.overleaf.com/learn/how-to/How_do_I_download_the_automatically_generated_files_(e.g._.bbl%2C_.aux%2C_.ind%2C_.gls)_for_my_project%3F_My_publisher_asked_me_to_include_them_in_my_submission

I changed this in #111 before realising this is very common