### PR TITLE
bug: fix three HTML bugs in docs

### DIFF
--- a/content/help/faq/versioning/contents.lr
+++ b/content/help/faq/versioning/contents.lr
@@ -103,7 +103,7 @@ category: versioning-col2
 #### qaitem ####
 question: Why do you include “zenodo” in the DOI?
 ----
-answer: Currently DOIs registered by Zenodo follows the pattern “10.5281/zenodo.<integer>” where 10.5281 is the Zenodo DOI prefix and <integer> is a sequentially assigned integer. The word “zenodo” is semantic information and, as mentioned in the previous answer, it is a bad idea to include semantic information in DOIs as it may change over time. The current practice was introduced when Zenodo was launched in May 2013, and while it is not ideal we did not want to change the existing practice.
+answer: Currently DOIs registered by Zenodo follows the pattern “10.5281/zenodo.&lt;integer&gt;” where 10.5281 is the Zenodo DOI prefix and &lt;integer&gt; is a sequentially assigned integer. The word “zenodo” is semantic information and, as mentioned in the previous answer, it is a bad idea to include semantic information in DOIs as it may change over time. The current practice was introduced when Zenodo was launched in May 2013, and while it is not ideal we did not want to change the existing practice.
 ----
 category: versioning-col2
 #### qaitem ####

--- a/templates/base.html
+++ b/templates/base.html
@@ -127,6 +127,7 @@
                   <li><a href="https://help.zenodo.org/faq/">FAQ</a></li>
                   <li><a href="https://help.zenodo.org/guides/">Guides</a></li>
                   <li><a href="https://zenodo.org/support">Support</a></li>
+                </ul>
               </div>
               <div class="col-xs-2 col-md-2">
                 <h5>Developers</h5>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -27,7 +27,7 @@
 {%- for child in children %}
 <h3 id="{{child._id}}">{{ child.title}}</h3>
 {{child.toptext}}
-<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+<div class="panel-group" role="tablist" aria-multiselectable="true">
 {%- for blk in child.faqlist.blocks %}
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="h{{child._id}}-{{loop.index}}">


### PR DESCRIPTION
- `div#accordion` is repeated several times on the page which is invalid and if it is used currently it wouldn't work for the subsequent uses. As such I don't believe it is used and the page doesn't break when it was removed when testing
- `<integer>` was never displayed on the page as it is interpreted as an HTML tag
- add missing `</ul>` tag