### PR TITLE
UI: Add dropdown markers to roadmap

### DIFF
--- a/assets/static/zenodo.css
+++ b/assets/static/zenodo.css
@@ -26,8 +26,7 @@ hgroup,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 
@@ -220,6 +219,16 @@ table {
 td,
 th {
   padding: 0;
+}
+
+details summary { 
+  border-bottom: 1px #eee solid;
+  padding: 1em 0;
+  margin: 1em 0;
+}
+
+details summary > * {
+  display: inline;
 }
 
 /*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -5,7 +5,7 @@
 {% block body %}
 <section class="roadmap-section">
     <div class="container">
-        <div clas="row">
+        <div class="row">
             <h1>Roadmap</h1>
             <hr />
         </div>
@@ -32,7 +32,7 @@
                 {%- endfor %}
             </div>
         </div>
-        <div clas="row">
+        <div class="row">
             <div class="col-md-8 col-md-offset-2 text-center">
                 Our roadmap helps us share what we are working on next and the direction that we're taking Zenodo. <br>The roadmap is updated quarterly in January, April, July and October. Questions, comments and feedback? <a href="https://zenodo.org/support">Contact us</a>
                 </p>
@@ -49,7 +49,6 @@
                         <details {{ 'open' if year >= (today().year - 1) }}>
                             <summary>
                                 <h3>{{ year }}</h3>
-                                <hr />
                             </summary>
                             <div class="row">
                                 {%- for card in cards %}


### PR DESCRIPTION
https://about.zenodo.org/roadmap/

At first glance it looks like we don't have achievements in previous years as there is no indication it is a dropdown

### Before

<img width="1693" alt="image" src="https://github.com/zenodo/zenodo-docs-user/assets/6676843/4f15d055-6340-4746-b2a8-fafb62ebe187">
<img width="1700" alt="image" src="https://github.com/zenodo/zenodo-docs-user/assets/6676843/64b77580-0b1d-4002-ad9e-ea0900c9c793">

### After 
<img width="1695" alt="image" src="https://github.com/zenodo/zenodo-docs-user/assets/6676843/c935a823-41fd-4b36-895d-e2d85f100204">
<img width="1694" alt="image" src="https://github.com/zenodo/zenodo-docs-user/assets/6676843/e7a9f3ea-7262-4a4f-ade9-ca5974ee4ac9">
