### PR TITLE
Add cookie banner

### DIFF
--- a/assets/static/zenodo.css
+++ b/assets/static/zenodo.css
@@ -11493,6 +11493,8 @@ body.cover-page header .alert {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  max-width: 1170px;
+  margin: 1em auto;
 
   box-shadow: inset 0 0 0 1px rgba(34,36,38,.22),0 0 0 0 transparent;
   background-color: #f8ffff;
@@ -11501,8 +11503,55 @@ body.cover-page header .alert {
   margin-bottom: 1em;
   transition: opacity .1s ease,color .1s ease,background .1s ease,box-shadow .1s ease;
 
+  p {
+    margin: 0;
+  }
+
+  i.icon {
+    font-style: normal;
+    font-size: 1em;
+    width: 1.18em;
+    cursor: pointer;
+    opacity: .7;
+    position: absolute;
+    right: .5em;
+    top: .78575em;
+    transition: opacity .1s ease;
+  }
+
+  i.icon.close::before {
+    content: "✖️";
+  }
+
   .buttons {
     display: flex;
+
+    button {
+      background: #fff none;
+      border: none;
+      border-radius: .29rem;
+      color: #333;
+      font-family: Helvetica,Helvetica Neue,Arial,sans-serif;
+      line-height: 1em;
+      margin: 0 .25em 0 0;
+      padding: .79em 1.5em;
+      transition: opacity .1s ease,background-color .1s ease,color .1s ease,box-shadow .1s ease,background .1s ease;
+      box-shadow: inset 0 0 0 1px #adadad,inset 0 0 0 0 rgba(34,36,38,.15);
+    }
+
+    button:hover {
+      background-color: #e6e6e6;
+    }
+
+    button.primary {
+      background-color: #2f6fa7;
+      color: #fff;
+      box-shadow: inset 0 0 0 0 rgba(34,36,38,.15);
+    }
+
+    button.primary:hover {
+      background-color: #246298;
+    }
   }
 }
 

--- a/assets/static/zenodo.css
+++ b/assets/static/zenodo.css
@@ -11483,6 +11483,32 @@ body.cover-page header .alert {
   color: #a92121;
 }
 
+.cookie-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+  padding: 0.5em 1.75em 0.5em 1em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  box-shadow: inset 0 0 0 1px rgba(34,36,38,.22),0 0 0 0 transparent;
+  background-color: #f8ffff;
+  color: #0e576c;
+  border-radius: .29rem;
+  margin-bottom: 1em;
+  transition: opacity .1s ease,color .1s ease,background .1s ease,box-shadow .1s ease;
+
+  .buttons {
+    display: flex;
+  }
+}
+
+.cookie-banner.hidden {
+  display: none;
+}
 
 /*!
  * angular-loading-bar v0.9.0

--- a/content/about/cookie-policy/contents.lr
+++ b/content/about/cookie-policy/contents.lr
@@ -66,7 +66,14 @@ See [aboutcookies.org](https://www.aboutcookies.org/how-to-manage-and-delete-coo
 
 #### Managing our analytics cookies
 
-Analytics cookies on Zenodo can be managed like described above. In addition, Zenodo supports a technology called "Do Not Track". The "Do Not Track" technology enables visitors to opt-out from being tracked by analytics cookies on websites for whatever purpose, including the use of analytics services.
+<div>
+You can change your preferences using the following buttons:
+<button class='hidden' id='all-consent'>Accept all cookies</button>
+<button class='hidden' id='essential-consent'>Accept only essential cookies</button>
+<button class='hidden' id='withdraw-consent'>Withdraw consent</button>
+</div>
+
+In addition, Zenodo supports a technology called "Do Not Track". The "Do Not Track" technology enables visitors to opt-out from being tracked by analytics cookies on websites for whatever purpose, including the use of analytics services.
 
 To enable the “do not track” option in your browser follow the respective link below:
 
@@ -84,3 +91,61 @@ If your preferred browser is not in the above list of browsers, visit the vendor
 See also our [privacy policy](../privacy-policy/)
 
 *Last revision: 2024-03-20*
+
+<script>
+function showButtons() {
+    var cookieConsent = document.cookie
+        .split("; ")
+        .find((row) => row.startsWith("cookie_consent="))
+        ?.split("=")[1];
+
+    if (cookieConsent) {
+        document.getElementById("withdraw-consent").classList.remove("hidden")
+        if (cookieConsent === "all") {
+            document.getElementById("all-consent").classList.add("hidden")
+            document.getElementById("essential-consent").classList.remove("hidden")
+        } else {
+            document.getElementById("essential-consent").classList.add("hidden")
+            document.getElementById("all-consent").classList.remove("hidden")
+        }
+    } else {
+        document.getElementById("withdraw-consent").classList.add("hidden")
+        document.getElementById("all-consent").classList.remove("hidden")
+        document.getElementById("essential-consent").classList.remove("hidden")
+    }
+}
+
+showButtons()
+
+$('#all-consent')
+    .on('click', function () {
+        $('.cookie-banner').fadeOut('fast');
+        setCookie("cookie_consent","all");
+        _paq.push(['rememberCookieConsentGiven']);
+        matomo();
+        showButtons()
+    });
+
+$('#essential-consent')
+    .on('click', function ()  {
+        $('.cookie-banner').fadeOut('fast');
+        setCookie("cookie_consent","essential");
+        showButtons()
+    });
+
+$('#withdraw-consent')
+    .on('click', function () {
+        document.querySelector(".cookie-banner").classList.remove("hidden")
+        $('.cookie-banner').fadeIn('fast');
+        unsetCookie("cookie_consent");
+        _paq.push(['forgetCookieConsentGiven']);
+        showButtons()
+    });
+
+function unsetCookie(cname) {
+    var expires = "expires=Thu, 01 Jan 1970 00:00:00 UTC";
+    var cookie = cname + "=;" + expires + ";"
+    cookie += "path=.zenodo.org;SameSite=None; Secure";
+    document.cookie = cookie;
+}
+</script>

--- a/templates/base-about.html
+++ b/templates/base-about.html
@@ -30,20 +30,7 @@
 {% endblock %}
 {% block title %}{{ this.title }}{% endblock %}
 {% block body %}{{ this.body }}{% endblock %}
+{% from "macros/cookie-banner.html" import cookie_banner %}
 {% block trackingcode %}
-<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="https://webanalytics.web.cern.ch/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '361']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code -->
+  {{ cookie_banner(361) }}
 {% endblock %}

--- a/templates/base-blog.html
+++ b/templates/base-blog.html
@@ -24,20 +24,7 @@
 {% block subnavbar %}{% endblock %}
 {% block title %}Zenodo Blog{% endblock %}
 {% block body %}{{ this.body }}{% endblock %}
+{% from "macros/cookie-banner.html" import cookie_banner %}
 {% block trackingcode %}
-<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="https://webanalytics.web.cern.ch/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '362']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code -->
+  {{ cookie_banner(362) }}
 {% endblock %}

--- a/templates/base-help.html
+++ b/templates/base-help.html
@@ -30,20 +30,8 @@
 {% endblock %}
 {% block title %}{{ this.title }}{% endblock %}
 {% block body %}{{ this.body }}{% endblock %}
+{% from "macros/cookie-banner.html" import cookie_banner %}
 {% block trackingcode %}
-<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="https://webanalytics.web.cern.ch/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '363']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code -->
+  {{ cookie_banner(363) }}
 {% endblock %}
+

--- a/templates/base-projects.html
+++ b/templates/base-projects.html
@@ -47,20 +47,7 @@
 {%- endfor %}
 {%- endblock %}
 
+{% from "macros/cookie-banner.html" import cookie_banner %}
 {% block trackingcode %}
-<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="https://webanalytics.web.cern.ch/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '363']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Matomo Code -->
+  {{ cookie_banner(363) }}
 {% endblock %}

--- a/templates/docsindex.html
+++ b/templates/docsindex.html
@@ -38,3 +38,8 @@
 <div class="alert alert-info" style="margin-top: 20px;">
 Couldn't find the answer to your question? <a href="https://zenodo.org/support">Contact us</a>.
 {% endblock %}
+
+{% from "macros/cookie-banner.html" import cookie_banner %}
+{% block trackingcode %}
+  {{ cookie_banner(363) }}
+{% endblock %}

--- a/templates/docspage.html
+++ b/templates/docspage.html
@@ -73,3 +73,8 @@
     </div>
 </div>
 {% endblock %}
+
+{% from "macros/cookie-banner.html" import cookie_banner %}
+{% block trackingcode %}
+  {{ cookie_banner(363) }}
+{% endblock %}

--- a/templates/macros/cookie-banner.html
+++ b/templates/macros/cookie-banner.html
@@ -1,0 +1,104 @@
+{#
+    # Copyright (C) 2024 CERN.
+    #
+    # Zenodo is free software; you can redistribute it and/or
+    # modify it under the terms of the GNU General Public License as
+    # published by the Free Software Foundation; either version 2 of the
+    # License, or (at your option) any later version.
+    #
+    # Zenodo is distributed in the hope that it will be useful, but
+    # WITHOUT ANY WARRANTY; without even the implied warranty of
+    # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    # General Public License for more details.
+    #
+    # You should have received a copy of the GNU General Public License
+    # along with Zenodo; if not, write to the Free Software Foundation, Inc.,
+    # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+    #
+    # In applying this license, CERN does not waive the privileges and immunities
+    # granted to it by virtue of its status as an Intergovernmental Organization or
+    # submit itself to any jurisdiction.
+-#}
+{% macro cookie_banner(matomo_id) %}
+<div class="cookie-banner hidden">
+    <i class="close icon"></i>
+    <div>
+        <i aria-hidden="true" class="info icon"></i>
+        <p class="inline">This site uses cookies. Find out more on <a href="https://about.zenodo.org/cookie-policy">how we use cookies</a></p>
+    </div>
+    <div class="buttons">
+        <button class="ui button small primary" id="cookies-all">Accept all cookies</button>
+        <button class="ui button small" id="cookies-essential">Accept only essential cookies</button>
+    </div>
+</div>
+
+<script>
+    console.log("hello")
+var _paq = window._paq = window._paq || [];
+_paq.push(['requireCookieConsent']);
+
+(function() {
+    var u="https://webanalytics.web.cern.ch/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '{{ matomo_id }}']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();
+
+const cookieConsent = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("cookie_consent="))
+    ?.split("=")[1];
+
+if (cookieConsent) {
+    if (cookieConsent === "all") {
+    matomo();
+    }
+} else {
+    console.log("unhide")
+    document.querySelector(".cookie-banner").classList.remove("hidden")
+    _paq.push(['forgetConsentGiven']);
+}
+
+$('.cookie-banner .close')
+    .on('click', function () {
+    $(this)
+        .closest('.message')
+        .transition('fade');
+    setCookie("cookie_consent","essential");
+    });
+
+$('#cookies-essential')
+    .on('click', function () {
+    $(this)
+        .closest('.message')
+        .transition('fade');
+    setCookie("cookie_consent","essential");
+    });
+
+$('#cookies-all')
+    .on('click', function () {
+    $(this)
+        .closest('.message')
+        .transition('fade');
+    setCookie("cookie_consent","all");
+    _paq.push(['rememberCookieConsentGiven']);
+    matomo();
+    });
+
+function matomo() {
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+}
+// TODO: path should equal .zenodo.org so as to set the cookie on the root level
+function setCookie(cname, cvalue) {
+    var d = new Date();
+    d.setTime(d.getTime() + (365 * 24 * 60 * 60 * 1000)); // one year
+    var expires = "expires=" + d.toUTCString();
+    var cookie = cname + "=" + cvalue + ";" + expires + ";"
+    cookie += "path=/;SameSite=None; Secure"; // so that it works across subdomains
+    document.cookie = cookie;
+}
+</script>
+{% endmacro %}

--- a/templates/macros/cookie-banner.html
+++ b/templates/macros/cookie-banner.html
@@ -23,12 +23,11 @@
 <div class="cookie-banner hidden">
     <i class="close icon"></i>
     <div>
-        <i aria-hidden="true" class="info icon"></i>
-        <p class="inline">This site uses cookies. Find out more on <a href="https://about.zenodo.org/cookie-policy">how we use cookies</a></p>
+        <p >This site uses cookies. Find out more on <a href="https://about.zenodo.org/cookie-policy">how we use cookies</a></p>
     </div>
     <div class="buttons">
-        <button class="ui button small primary" id="cookies-all">Accept all cookies</button>
-        <button class="ui button small" id="cookies-essential">Accept only essential cookies</button>
+        <button class="small primary" id="cookies-all">Accept all cookies</button>
+        <button class="small" id="cookies-essential">Accept only essential cookies</button>
     </div>
 </div>
 
@@ -101,4 +100,5 @@ function setCookie(cname, cvalue) {
     document.cookie = cookie;
 }
 </script>
+
 {% endmacro %}

--- a/templates/macros/cookie-banner.html
+++ b/templates/macros/cookie-banner.html
@@ -43,14 +43,14 @@ _paq.push(['requireCookieConsent']);
     g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
 })();
 
-const cookieConsent = document.cookie
+var cookieConsent = document.cookie
     .split("; ")
     .find((row) => row.startsWith("cookie_consent="))
     ?.split("=")[1];
 
 if (cookieConsent) {
     if (cookieConsent === "all") {
-    matomo();
+        matomo();
     }
 } else {
     document.querySelector(".cookie-banner").classList.remove("hidden")

--- a/templates/macros/cookie-banner.html
+++ b/templates/macros/cookie-banner.html
@@ -32,7 +32,6 @@
 </div>
 
 <script>
-    console.log("hello")
 var _paq = window._paq = window._paq || [];
 _paq.push(['requireCookieConsent']);
 
@@ -54,7 +53,6 @@ if (cookieConsent) {
     matomo();
     }
 } else {
-    console.log("unhide")
     document.querySelector(".cookie-banner").classList.remove("hidden")
     _paq.push(['forgetConsentGiven']);
 }
@@ -62,24 +60,24 @@ if (cookieConsent) {
 $('.cookie-banner .close')
     .on('click', function () {
     $(this)
-        .closest('.message')
-        .transition('fade');
+        .closest('.cookie-banner')
+        .fadeOut('fast');
     setCookie("cookie_consent","essential");
     });
 
 $('#cookies-essential')
     .on('click', function () {
     $(this)
-        .closest('.message')
-        .transition('fade');
+        .closest('.cookie-banner')
+        .fadeOut('fast');
     setCookie("cookie_consent","essential");
     });
 
 $('#cookies-all')
     .on('click', function () {
     $(this)
-        .closest('.message')
-        .transition('fade');
+        .closest('.cookie-banner')
+        .fadeOut('fast');
     setCookie("cookie_consent","all");
     _paq.push(['rememberCookieConsentGiven']);
     matomo();
@@ -90,13 +88,13 @@ function matomo() {
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
 }
-// TODO: path should equal .zenodo.org so as to set the cookie on the root level
+
 function setCookie(cname, cvalue) {
     var d = new Date();
     d.setTime(d.getTime() + (365 * 24 * 60 * 60 * 1000)); // one year
     var expires = "expires=" + d.toUTCString();
     var cookie = cname + "=" + cvalue + ";" + expires + ";"
-    cookie += "path=/;SameSite=None; Secure"; // so that it works across subdomains
+    cookie += "path=.zenodo.org;SameSite=None; Secure"; // so that it works across subdomains
     document.cookie = cookie;
 }
 </script>

--- a/templates/projectitem.html
+++ b/templates/projectitem.html
@@ -66,5 +66,7 @@
 </div>
 {% endblock %}
 
-
-
+{% from "macros/cookie-banner.html" import cookie_banner %}
+{% block trackingcode %}
+  {{ cookie_banner(361) }}
+{% endblock %}


### PR DESCRIPTION
Close https://github.com/zenodo/zenodo-rdm/issues/759

Currently the Matomo tracking code is repeated in individual templates (base-about.html, base-blog.html, base-help.html etc)

This PR refactors these repeated code blocks into a macro which passes the site ID for the analytics and introduces tracking to the pages which had been forgotten.

Additionally the cookie banner from https://github.com/zenodo/zenodo-rdm/pull/766 is introduced. As we don't have Semantic UI, I have imported the minimal set of styles to make it look okay and adjusted the Javascript to not use Semanic UI's `.fade`. Finally we set the cookie on `.zenodo.org` rather than `/` so that the cookie works across domains.

Note: do we need to link to cookie policy on https://developers.zenodo.org/? I believe we don't use tracking cookies here

![image](https://github.com/zenodo/zenodo-docs-user/assets/6676843/ff738adf-c0d8-4d42-ad0e-fc99b134ee4f)