### PR TITLE
UI: fix footer height bug

### DIFF
--- a/assets/static/zenodo.css
+++ b/assets/static/zenodo.css
@@ -10654,24 +10654,6 @@ body .body-container > .row {
   color: #c9e5ff;
 }
 
-@media (min-width: 992px) {
-  .footer {
-    height: 273px;
-  }
-}
-
-@media (max-width: 991px) and (min-width: 768px) {
-  .footer {
-    height: 397px;
-  }
-}
-
-@media (max-width: 767px) {
-  .footer {
-    height: 427px;
-  }
-}
-
 .footer a {
   color: #fff;
 }


### PR DESCRIPTION
At the moment the footer looks like this on the subdomains:

![image](https://github.com/zenodo/zenodo-docs-user/assets/6676843/d0481fa4-4b19-4ebe-9dba-26822f986231)

![image](https://github.com/zenodo/zenodo-docs-user/assets/6676843/14a51b62-b2c8-4f74-8229-cf466573aaa6)

![image](https://github.com/zenodo/zenodo-docs-user/assets/6676843/2e039da7-5047-4825-b5c2-d6903762022e)


after: 

![image](https://github.com/zenodo/zenodo-docs-user/assets/6676843/c099b9c1-f57c-40bb-b90d-23349fd94e2c)

![image](https://github.com/zenodo/zenodo-docs-user/assets/6676843/7555b721-d8e2-4ffb-a387-473b28f1e2d3)

![image](https://github.com/zenodo/zenodo-docs-user/assets/6676843/e3037e26-158a-4a22-b802-a21c4c4ba224)


