### PR TITLE
bug: fix HTML title

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,7 +50,7 @@
 <link rel="stylesheet" href="{{ '/static/style.css'|url }}">
 <link rel="stylesheet" href="{{ '/static/font-awesome/css/font-awesome.min.css'|url}}">
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,100,italic" rel="stylesheet">
-<title>{% if title %}{% block title %}{% endblock %} | {% endif %}Zenodo</title>
+<title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Zenodo</title>
 <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 </head>


### PR DESCRIPTION
Close https://github.com/zenodo/ops/issues/390

Change:

```jinja2
<title>{% if title %}{% block title %}{% endblock %} | {% endif %}Zenodo</title>
```

to
 
```jinja2
<title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Zenodo</title>
```

The error is that the person who wrote this confused `title` for a variable when it is a block. Ref https://stackoverflow.com/questions/18720899/how-can-i-determine-if-a-jinja2-template-block-is-empty